### PR TITLE
docs: update README to reflect current state of 1st gen os2display project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+> [!Important]
+> 
+> ### This project is no longer actively maintained.
+> 
+> The source code in this repository is no longer maintained. It has been superseded by [version 2](https://os2display.github.io/display-docs/), which offers improved features and better support.
+> 
+> Thank you to all who have contributed to this project. We recommend transitioning to [Os2Display version 2](https://os2display.github.io/display-docs/) for continued support and updates.
+> 
+> **Final Release**: The final stable release is version [2.2.0](https://github.com/os2display/default-template-bundle/releases/tag/2.2.0)
+<br>
+
+
 # Os2Display default template
 
 Installation:


### PR DESCRIPTION
@tuj Added an "Important note" similar to the PR to all the other `.*-bundle$` repos in the os2display org.